### PR TITLE
Fix OpenRemote theme identity provider login

### DIFF
--- a/theme/src/main/resources/theme/openremote/login/login.ftl
+++ b/theme/src/main/resources/theme/openremote/login/login.ftl
@@ -6,6 +6,12 @@
         ${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!'')))?no_esc}
     <#elseif section = "form">
         <#if realm.password>
+
+        <#if social.providers??>
+            <hr/>
+            <h4>${msg("localLoginLabel")}</h4>
+        </#if>
+
         <form onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
             <div class="row">
                 <div class="input-field col s12">
@@ -78,29 +84,22 @@
         </form>
         </#if>
     <#elseif section = "info" >
-
         <#if realm.password && realm.registrationAllowed && !usernameEditDisabled??>
             <div id="kc-registration">
                 <span>${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a></span>
             </div>
         </#if>
-
-
+    <#elseif section = "socialProviders" >
         <#if realm.password && social.providers??>
-            <div id="kc-social-providers">
-                <ul>
+            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
+                <h4>${msg("identityProviderLoginLabel")}</h4>
+                <div class="button-container">
                     <#list social.providers as p>
-                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
-                           type="button" href="${p.loginUrl}">
-                            <#if p.iconClasses?has_content>
-                                <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
-                                <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${p.displayName!}</span>
-                            <#else>
-                                <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName!}</span>
-                            </#if>
-                        </a>
+                        <form action="${p.loginUrl}" method="post">
+                            <button class="btn waves-effect waves-light">${p.displayName}</button>
+                        </form>
                     </#list>
-                </ul>
+                </div>
             </div>
         </#if>
     </#if>

--- a/theme/src/main/resources/theme/openremote/login/messages/messages_en.properties
+++ b/theme/src/main/resources/theme/openremote/login/messages/messages_en.properties
@@ -6,3 +6,5 @@ registerTitleHtml=Registration
 select2faDevice=Select your 2FA device
 passwordOld=Old Password
 incorrectOldPassword=The old password is incorrect
+localLoginLabel=Sign in locally
+identityProviderLoginLabel=Sign in online

--- a/theme/src/main/resources/theme/openremote/login/resources/css/styles.css
+++ b/theme/src/main/resources/theme/openremote/login/resources/css/styles.css
@@ -134,3 +134,15 @@ i.material-icons {
     position: relative;
     opacity: 1;
 }
+
+hr {
+    margin: 40px 0;
+}
+
+.button-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    padding: 10px;
+}

--- a/theme/src/main/resources/theme/openremote/login/template.ftl
+++ b/theme/src/main/resources/theme/openremote/login/template.ftl
@@ -76,6 +76,9 @@
                     </#if>
 
                     <div class="col s12">
+                        <#nested "socialProviders">
+                    </div>
+                     <div class="col s12">
                         <#nested "form">
                     </div>
                 </div>


### PR DESCRIPTION
This fixes the configured identity providers not showing when using the OpenRemote theme in Keycloak:

![idp](https://github.com/user-attachments/assets/4c8e0383-dcb7-4ce2-97a8-e5734b9cb386)

When no identity providers are configured it will show the login screen like it was before.