### PR TITLE
Update Keycloak to v26.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Keycloak image built for postgresql support with theme handling customisation
 # to always fallback to standard openremote theme.
 # ------------------------------------------------------------------------------------
-ARG VERSION=23.0
+ARG VERSION=26.3.4
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 MAINTAINER support@openremote.io
 


### PR DESCRIPTION
This PR updates Keycloak from v23 to v26. 

One main reason I opened this PR is because my mTLS implementation would potentially need the `TOKEN_EXCHANGE_STANDARD_V2` provider to perform token exchange between the manager and the authenticating user based off of their certificate's CN.

I'm not exactly sure what the validation steps are to merging this, please let me know if there's anything specific that I need to test!