### PR TITLE
Fix resetting forgotten passwords

### DIFF
--- a/theme/src/main/resources/theme/openremote/login/login-update-password.ftl
+++ b/theme/src/main/resources/theme/openremote/login/login-update-password.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password-old','password','password-confirm'); section>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password','password-confirm'); section>
     <#if section = "header">
         ${msg("updatePasswordTitle")}
     <#elseif section = "form">
@@ -7,18 +7,7 @@
             <div class="row">
                 <input type="text" id="username" name="username" value="${username}" autocomplete="username"
                        readonly="readonly" style="display:none;"/>
-                <div class="input-field col s12">
-                    <input type="password" id="password-old" name="password-old"
-                           class="validate <#if messagesPerField.existsError('password-old')>invalid</#if>"
-                           required
-                           autofocus autocomplete="new-password"
-                           aria-invalid="<#if messagesPerField.existsError('password-old')>true</#if>"
-                    />
-                    <label for="password-old" class="${properties.kcLabelClass!}">${msg("passwordOld")}</label>
-                    <#if messagesPerField.existsError('password-old')>
-                        <span class="helper-text" data-error="${kcSanitize(messagesPerField.getFirstError('password-old'))?no_esc}"></span>
-                    </#if>
-                </div>
+                <input type="password" id="password" name="password" autocomplete="current-password" style="display:none;"/>
 
                 <div class="input-field col s12">
                     <input type="password" id="password-new" name="password-new"

--- a/theme/src/main/resources/theme/openremote/login/messages/messages_en.properties
+++ b/theme/src/main/resources/theme/openremote/login/messages/messages_en.properties
@@ -4,7 +4,5 @@ logoUrl=https://openremote.io
 registerTitle=Registration
 registerTitleHtml=Registration
 select2faDevice=Select your 2FA device
-passwordOld=Old Password
-incorrectOldPassword=The old password is incorrect
 localLoginLabel=Sign in locally
 identityProviderLoginLabel=Sign in online


### PR DESCRIPTION
The UPDATE_PASSWORD action is used when users forget their password. They cannot enter their old password in this case because they do not know this.

Requesting users to enter their current password when changing password may also not add any additional security. This is because users can also use the forgotten password flow to reset it without having to enter their current password.

Fixes #21