### PR TITLE
Modernize Gradle dependency management

### DIFF
--- a/fixed-issuer/build.gradle
+++ b/fixed-issuer/build.gradle
@@ -15,16 +15,16 @@ repositories {
 }
 
 dependencies {
-    implementation "org.keycloak:keycloak-services:$keycloakVersion"
-    implementation "org.keycloak:keycloak-server-spi:$keycloakVersion"
-    implementation "net.bytebuddy:byte-buddy:$byteBuddyVersion"
-    implementation "net.bytebuddy:byte-buddy-agent:$byteBuddyVersion"
-    jarLibs "net.bytebuddy:byte-buddy-agent:$byteBuddyVersion"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    compileOnly "org.projectlombok:lombok:$lombokVersion"
-    annotationProcessor "org.projectlombok:lombok:$lombokVersion"
-    compileOnly "com.google.auto.service:auto-service:$autoServiceVersion"
-    annotationProcessor "com.google.auto.service:auto-service:$autoServiceVersion"
+    implementation libs.keycloakServices
+    implementation libs.keycloakServerSpi
+    implementation libs.byteBuddy
+    implementation libs.byteBuddyAgent
+    jarLibs libs.byteBuddyAgent
+    implementation libs.slf4jApi
+    compileOnly libs.lombok
+    annotationProcessor libs.lombok
+    compileOnly libs.autoService
+    annotationProcessor libs.autoService
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,1 @@
-keycloakVersion = 26.6.4
-byteBuddyVersion = 1.17.5
-slf4jVersion = 2.0.17
-lombokVersion = 1.18.38
-autoServiceVersion = 1.1.1
-jbossLoggingVersion = 3.6.1.Final
+org.gradle.configuration-cache=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,19 @@
+[versions]
+autoService = "1.1.1"
+byteBuddy = "1.17.5"
+jbossLogging = "3.6.1.Final"
+keycloak = "26.6.4"
+lombok = "1.18.38"
+slf4j = "2.0.17"
+
+[libraries]
+autoService = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
+byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
+byteBuddyAgent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byteBuddy" }
+jbossLogging = { module = "org.jboss.logging:jboss-logging", version.ref = "jbossLogging" }
+keycloakCore = { module = "org.keycloak:keycloak-core", version.ref = "keycloak" }
+keycloakServerSpi = { module = "org.keycloak:keycloak-server-spi", version.ref = "keycloak" }
+keycloakServerSpiPrivate = { module = "org.keycloak:keycloak-server-spi-private", version.ref = "keycloak" }
+keycloakServices = { module = "org.keycloak:keycloak-services", version.ref = "keycloak" }
+lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
+slf4jApi = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/self-register-user-configure/build.gradle
+++ b/self-register-user-configure/build.gradle
@@ -15,10 +15,10 @@ repositories {
 }
 
 dependencies {
-    implementation "org.keycloak:keycloak-server-spi:$keycloakVersion"
-    implementation "org.keycloak:keycloak-server-spi-private:$keycloakVersion"
-    implementation "org.keycloak:keycloak-core:$keycloakVersion"
-    implementation "org.jboss.logging:jboss-logging:$jbossLoggingVersion"
+    implementation libs.keycloakServerSpi
+    implementation libs.keycloakServerSpiPrivate
+    implementation libs.keycloakCore
+    implementation libs.jbossLogging
 }
 
 jar {
@@ -35,5 +35,5 @@ tasks.register('installDist', Copy) {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.release = 17
+    options.release = 21
 }


### PR DESCRIPTION
* Move dependency versions to a Gradle version catalog
* Replace version properties with type-safe library aliases
* Enable the Gradle configuration cache
* Remove obsolete dependency version properties